### PR TITLE
state changes were going so fast they were bounced so that the status…

### DIFF
--- a/src/components/MediaPlayer.tsx
+++ b/src/components/MediaPlayer.tsx
@@ -36,7 +36,7 @@ export function MediaPlayer(props: IProps) {
 
   useEffect(() => {
     if (mediaState.status === MediaSt.FETCHED) setReady(true);
-  }, [mediaState.status]);
+  }, [mediaState]);
 
   useEffect(() => {
     if (ready && audioRef.current && !playing && playItem !== '') {


### PR DESCRIPTION
… didn't change.  The pending state changes the id also, so that forces the useEffect to trigger.