### PR TITLE
prevent duplicate createorg.  Online is only used in error case, so d…

### DIFF
--- a/src/crud/useTeamCreate.ts
+++ b/src/crud/useTeamCreate.ts
@@ -135,9 +135,10 @@ export const useTeamCreate = (props: IProps) => {
           if (cb) cb(org);
         })
         .catch((err) => {
-          checkOnline((online) =>
-            offlineError({ ...props, online, showMessage, err })
-          );
+          checkOnline((online) => {
+            workingOnItRef.current = false;
+            offlineError({ ...props, online, showMessage, err });
+          });
         });
     }
   };


### PR DESCRIPTION
…on't bother checking unless we get an error.  This was a holdover from when orgs had to be created online.