### PR TITLE
TT-2356 store the passagestatechange message in the eafurl on mediafi…

### DIFF
--- a/src/components/Uploader.tsx
+++ b/src/components/Uploader.tsx
@@ -12,7 +12,9 @@ import {
   pullPlanMedia,
   related,
   remoteIdNum,
+  useArtifactType,
   useOfflnMediafileCreate,
+  VernacularTag,
 } from '../crud';
 import Auth from '../auth/Auth';
 import Memory from '@orbit/memory';
@@ -73,6 +75,7 @@ export const Uploader = (props: IProps) => {
     allowWave,
     defaultFilename,
     t,
+    ts,
     isOpen,
     onOpen,
     showMessage,
@@ -108,7 +111,7 @@ export const Uploader = (props: IProps) => {
   const artifactTypeRef = useRef<string>('');
   const { createMedia } = useOfflnMediafileCreate(doOrbitError);
   const [, setComplete] = useGlobal('progress');
-
+  const { localizedArtifactTypeFromId } = useArtifactType();
   const finishMessage = () => {
     setTimeout(() => {
       if (fileList.current)
@@ -195,6 +198,9 @@ export const Uploader = (props: IProps) => {
       sourceMediaId: getSourceMediaId(),
       sourceSegments: sourceSegments,
       performedBy: performedBy,
+      eafUrl: !artifactTypeId
+        ? ts.mediaAttached
+        : localizedArtifactTypeFromId(artifactTypeId), //put psc message here
     } as any;
     if (recordAudio) mediaFile.recordedbyUserId = getUserId();
     nextUpload(


### PR DESCRIPTION
…le create (so it's properly localized).  Backend will grab it and create a passagestatechange record, then clear the eafurl.