### PR TITLE
TT-3562 Add ids

### DIFF
--- a/src/components/Discussions/DiscussionCard.tsx
+++ b/src/components/Discussions/DiscussionCard.tsx
@@ -186,6 +186,7 @@ interface IStateProps {
   ts: ISharedStrings;
 }
 interface IProps extends IRecordProps, IStateProps {
+  id: string;
   auth: Auth;
   discussion: Discussion;
   collapsed: boolean;
@@ -197,6 +198,7 @@ interface IProps extends IRecordProps, IStateProps {
 export const DiscussionCard = (props: IProps) => {
   const classes = useStyles();
   const {
+    id,
     t,
     ts,
     auth,
@@ -621,7 +623,7 @@ export const DiscussionCard = (props: IProps) => {
     <div className={classes.root}>
       <Card
         key={discussion.id}
-        id={`card-${discussion.id}`}
+        id={id}
         className={
           discussion.attributes.resolved ? classes.resolvedcard : classes.card
         }

--- a/src/components/Discussions/DiscussionList.tsx
+++ b/src/components/Discussions/DiscussionList.tsx
@@ -348,6 +348,7 @@ export function DiscussionList(props: IProps) {
         <Grid container className={classes.cardFlow}>
           {displayDiscussions.map((i, j) => (
             <DiscussionCard
+              id={`card-${j}`}
               auth={auth}
               key={j}
               discussion={i}

--- a/src/components/Integration.tsx
+++ b/src/components/Integration.tsx
@@ -636,7 +636,7 @@ export function IntegrationPanel(props: IProps) {
 
   return (
     <div className={classes.root}>
-      <Accordion defaultExpanded={!offline} disabled={offline}>
+      <Accordion id="int-online" defaultExpanded={!offline} disabled={offline}>
         <AccordionSummary
           expandIcon={<ExpandMoreIcon />}
           aria-controls={t.paratext}
@@ -648,7 +648,7 @@ export function IntegrationPanel(props: IProps) {
           </Typography>
         </AccordionSummary>
         <AccordionDetails className={classes.panel}>
-          <List dense component="div">
+          <List id="onl-criteria" dense component="div">
             <ListItem id="onlineexporttype" key="export-type">
               <ListItemAvatar>
                 <Avatar className={classes.avatar}>
@@ -822,7 +822,7 @@ export function IntegrationPanel(props: IProps) {
           </FormControl>
         </AccordionDetails>
       </Accordion>
-      <Accordion defaultExpanded={offline} disabled={!offline}>
+      <Accordion id="int-offln" defaultExpanded={offline} disabled={!offline}>
         <AccordionSummary
           expandIcon={<ExpandMoreIcon />}
           aria-controls={t.paratextLocal}
@@ -834,7 +834,7 @@ export function IntegrationPanel(props: IProps) {
           </Typography>
         </AccordionSummary>
         <AccordionDetails className={classes.panel}>
-          <List dense component="div">
+          <List id="offln-criteria" dense component="div">
             <ListItem key="export-type">
               <ListItemAvatar>
                 <Avatar className={classes.avatar}>

--- a/src/components/PassageDetail/Internalization/AddResource.tsx
+++ b/src/components/PassageDetail/Internalization/AddResource.tsx
@@ -75,6 +75,7 @@ export const AddResource = (props: IProps) => {
   return (
     <div>
       <Button
+        id="add-resource"
         onClick={handleClick}
         variant="contained"
         color="primary"

--- a/src/components/PassageDetail/Internalization/DoneButton.tsx
+++ b/src/components/PassageDetail/Internalization/DoneButton.tsx
@@ -17,7 +17,7 @@ const handleDone =
   };
 
 export const DoneButton = (props: IProps) => (
-  <IconButton onClick={handleDone(props)}>
-    {props.value ? <DoneIcon /> : <OpenIcon />}
+  <IconButton id="item-done" onClick={handleDone(props)}>
+    {props.value ? <DoneIcon id="done-yes" /> : <OpenIcon id="done-no" />}
   </IconButton>
 );

--- a/src/components/PassageDetail/Internalization/ResourceEditAction.tsx
+++ b/src/components/PassageDetail/Internalization/ResourceEditAction.tsx
@@ -20,11 +20,11 @@ export const ResourceEditAction = ({ item, onEdit, onDelete }: IProps) => {
   return (
     <span>
       {onEdit && (
-        <IconButton onClick={handleEdit(item)}>
+        <IconButton id={`res-edit`} onClick={handleEdit(item)}>
           <EditIcon />
         </IconButton>
       )}
-      <IconButton onClick={handleDelete(item)}>
+      <IconButton id={`res-delete`} onClick={handleDelete(item)}>
         <DeleteIcon />
       </IconButton>
     </span>

--- a/src/components/PassageDetail/Internalization/SelectResource.tsx
+++ b/src/components/PassageDetail/Internalization/SelectResource.tsx
@@ -134,7 +134,11 @@ export const SelectResource = (props: IProps) => {
             className={classes.listItem}
           >
             <ListItemIcon>
-              {selected.indexOf(i) !== -1 ? <Checked /> : <UnChecked />}
+              {selected.indexOf(i) !== -1 ? (
+                <Checked id={`res-${i}-yes`} />
+              ) : (
+                <UnChecked id={`res-${i}-no`} />
+              )}
             </ListItemIcon>
             <ListItemText
               primary={r.attributes?.reference}
@@ -148,6 +152,7 @@ export const SelectResource = (props: IProps) => {
       </List>
       <div className={classes.actions}>
         <Button
+          id="res-selected"
           onClick={handleSelect}
           variant="contained"
           className={classes.button}
@@ -157,6 +162,7 @@ export const SelectResource = (props: IProps) => {
           {ts.select}
         </Button>
         <Button
+          id="res-select-cancel"
           onClick={handleCancel}
           variant="contained"
           className={classes.button}

--- a/src/components/PassageDetail/Internalization/SortableList.tsx
+++ b/src/components/PassageDetail/Internalization/SortableList.tsx
@@ -3,6 +3,6 @@ import { SortableContainer } from 'react-sortable-hoc';
 
 export const SortableList = SortableContainer(
   ({ children }: { children: JSX.Element[] }) => {
-    return <List>{children}</List>;
+    return <List id="sortable-list">{children}</List>;
   }
 );

--- a/src/components/PassageDetail/PassageDetailItem.tsx
+++ b/src/components/PassageDetail/PassageDetailItem.tsx
@@ -504,11 +504,17 @@ export function PassageDetailItem(props: IProps) {
                             />
                             {playItem && (
                               <>
-                                <IconButton onClick={handleTranscribe}>
+                                <IconButton
+                                  id="load-transcriber"
+                                  onClick={handleTranscribe}
+                                >
                                   <TranscribeIcon />
                                 </IconButton>
                                 {projRole === RoleNames.Admin && (
-                                  <IconButton onClick={handleDelete(playItem)}>
+                                  <IconButton
+                                    id="delete-recording"
+                                    onClick={handleDelete(playItem)}
+                                  >
                                     <DeleteIcon />
                                   </IconButton>
                                 )}

--- a/src/components/PassageDetail/PassageDetailStepComplete.tsx
+++ b/src/components/PassageDetail/PassageDetailStepComplete.tsx
@@ -57,7 +57,11 @@ export const PassageDetailStepComplete = (props: IProps) => {
         title={t.title}
         onClick={handleToggleComplete}
       >
-        {complete ? <CompleteIcon /> : <NotCompleteIcon />}
+        {complete ? (
+          <CompleteIcon id="step-yes" />
+        ) : (
+          <NotCompleteIcon id="step-no" />
+        )}
       </IconButton>
     </div>
   );

--- a/src/components/PassageDetail/PassageDetailTranscribe.tsx
+++ b/src/components/PassageDetail/PassageDetailTranscribe.tsx
@@ -37,7 +37,12 @@ export function PassageDetailTranscribe(props: IProps) {
   if (view) return <StickyRedirect to={view} />;
 
   return (
-    <Button onClick={handleTranscribe} variant="contained" color="primary">
+    <Button
+      id="transcriber-step"
+      onClick={handleTranscribe}
+      variant="contained"
+      color="primary"
+    >
       {t.openTranscriber}
       <TranscribeIcon className={classes.icon} color="white" />
     </Button>

--- a/src/components/PassageDetail/SelectRecording.tsx
+++ b/src/components/PassageDetail/SelectRecording.tsx
@@ -137,7 +137,7 @@ export const SelectRecording = (props: IProps) => {
   return (
     <>
       <div className={classes.choice}>
-        <Button onClick={handleItem} variant="contained">
+        <Button id="select-recording" onClick={handleItem} variant="contained">
           {t.playItem}
         </Button>
         <ItemDescription

--- a/src/components/StepEditor/StepEditor.tsx
+++ b/src/components/StepEditor/StepEditor.tsx
@@ -260,7 +260,7 @@ export const StepEditor = ({ process, org }: IProps) => {
   return (
     <div>
       <div className={classes.row}>
-        <Button onClick={handleAdd} variant="contained">
+        <Button id="wk-step-add" onClick={handleAdd} variant="contained">
           {se.add}
         </Button>
         <div title={hiddenMessage}>

--- a/src/components/StepEditor/StepList.tsx
+++ b/src/components/StepEditor/StepList.tsx
@@ -3,6 +3,6 @@ import { SortableContainer } from 'react-sortable-hoc';
 
 export const StepList = SortableContainer(
   ({ children }: { children: JSX.Element[] }) => {
-    return <List>{children}</List>;
+    return <List id="sortable-steps">{children}</List>;
   }
 );

--- a/src/components/Transcriber.tsx
+++ b/src/components/Transcriber.tsx
@@ -971,7 +971,11 @@ export function Transcriber(props: IProps) {
             {jumpBack && (
               <div className={classes.grow}>
                 <div className={classes.grow}>{'\u00A0'}</div>
-                <Button onClick={handleWorkflow} variant="contained">
+                <Button
+                  id="back-to-workflow"
+                  onClick={handleWorkflow}
+                  variant="contained"
+                >
                   {t.backToWorkflow}
                 </Button>
               </div>
@@ -989,7 +993,7 @@ export function Transcriber(props: IProps) {
                 />
               </Grid>
               {jumpBack && (
-                <Grid item md={3} alignContent="flex-end">
+                <Grid item md={3} container alignContent="flex-end">
                   <Button onClick={handleWorkflow} variant="contained">
                     {t.backToWorkflow}
                   </Button>

--- a/src/control/SelectExportType.tsx
+++ b/src/control/SelectExportType.tsx
@@ -26,13 +26,14 @@ export const SelectExportType = (props: IProps) => {
 
   return (
     <TextField
+      id="select-export-type"
       select
       value={exportType}
       onChange={handleExportType}
       className={classes.typeSelect}
     >
       {exportTypes.map((t) => (
-        <MenuItem key={t} value={t}>
+        <MenuItem id={`exp-${t}`} key={t} value={t}>
           {localizedArtifactType(t)}
         </MenuItem>
       ))}


### PR DESCRIPTION
- on internalize list and on workflow editor list
(these are both sortable lists)
-  Add button on the Internalization stage
- Open Transcriber button on the Transcribe stage
- Back to Workflow button on Transcriber page
- the Sync with Paratext stage.
- online and offline lists on sync
- Play Item button on the back translation stages
- Vernacular drop down on the Export stage
(this button is also on the sync dialog)
- select and cancel button on shared resource
- check boxes for select recourse and completed now have separate ids
- discussion cards use sequential number for easier testing