### PR TITLE
TT-4768 use planid instead of project type as a replacement for proje…

### DIFF
--- a/src/components/App/AppHead.tsx
+++ b/src/components/App/AppHead.tsx
@@ -63,11 +63,13 @@ const ProjectName = ({ setView }: INameProps) => {
   const [, setProject] = useGlobal('project');
   const [, setProjType] = useGlobal('projType');
   const [plan, setPlan] = useGlobal('plan');
+  const [, setOrgRole] = useGlobal('orgRole');
 
   const handleHome = () => {
     setProject('');
     setPlan('');
     setProjType('');
+    setOrgRole(undefined);
     setView('Home');
   };
 

--- a/src/context/TeamContext.tsx
+++ b/src/context/TeamContext.tsx
@@ -229,7 +229,6 @@ const TeamProvider = withData(mapRecordsToProps)(
       setMyOrgRole(orgId);
       setProject(projectId);
       setProjectType(projectId);
-      setPlan(plan.id);
       return [projectId, orgId];
     };
 
@@ -249,6 +248,7 @@ const TeamProvider = withData(mapRecordsToProps)(
       const [projectId] = setProjectParams(plan);
       LoadData(projectId, () => {
         setProjectType(projectId);
+        setPlan(plan.id);
         if (cb) cb();
       });
     };

--- a/src/routes/TeamScreen.tsx
+++ b/src/routes/TeamScreen.tsx
@@ -27,7 +27,7 @@ export const TeamScreen = () => {
   }, []);
 
   useEffect(() => {
-    if (project !== '' && projType) {
+    if (project !== '' && plan) {
       const remProjId = remoteId('plan', plan, memory.keyMap);
       const loc = `/plan/${remProjId || plan}/0`;
       if (loc !== localStorage.getItem(localUserKey(LocalKey.url))) {


### PR DESCRIPTION
…ct role

to determine if we're ready to open the project.  Project type is needed for the project card.