### PR TITLE
TT-5007 Retain fetched Url

### DIFF
--- a/src/crud/useFetchMediaUrl.ts
+++ b/src/crud/useFetchMediaUrl.ts
@@ -103,7 +103,8 @@ export const useFetchMediaUrl = (reporter?: any) => {
 
     const cancelled = () => {
       if (cancelRequest) {
-        dispatch({ payload: undefined, type: MediaSt.IDLE });
+        // setting to idle here clears the fetched url when component refreshed
+        // dispatch({ payload: undefined, type: MediaSt.IDLE });
         return true;
       }
       return false;


### PR DESCRIPTION
- even when cancelling after fetching
- cancel happens on refresh so don't forget loaded url