### PR TITLE
TT-4929 record elements sizing

### DIFF
--- a/src/components/Discussions/DiscussionMove.tsx
+++ b/src/components/Discussions/DiscussionMove.tsx
@@ -14,7 +14,6 @@ export const DiscussionMove = ({ onSelect }: IProps) => {
   const { workflow } = usePassageDetailContext();
 
   const handle = (id: string) => () => {
-    console.log(`choice is ${id}`);
     onSelect(id);
   };
 

--- a/src/components/PassageDetail/PassageDetailChooser.tsx
+++ b/src/components/PassageDetail/PassageDetailChooser.tsx
@@ -14,10 +14,16 @@ import { useSelector, shallowEqual } from 'react-redux';
 import { passageChooserSelector } from '../../selector';
 import { usePassageNavigate } from './usePassageNavigate';
 
-const StyledBox = styled(Box)<BoxProps>(({ theme }) => ({
-  padding: `0 ${theme.spacing(6)}px`,
+interface StyledBoxProps extends BoxProps {
+  noOnLeft?: boolean;
+}
+const StyledBox = styled(Box, {
+  shouldForwardProp: (prop) => prop !== 'width',
+})<StyledBoxProps>(({ width, theme }) => ({
+  padding: `${theme.spacing(2)}px ${theme.spacing(6)}px`,
   display: 'flex',
   flexDirection: 'row',
+  width: `${width}px`,
 }));
 
 interface Mark {
@@ -25,7 +31,11 @@ interface Mark {
   label: string;
 }
 
-export const PassageDetailChooser = () => {
+interface IProps {
+  width: number;
+}
+
+export const PassageDetailChooser = ({ width }: IProps) => {
   const [memory] = useGlobal('memory');
   const { passage, section, prjId, allBookData } = usePassageDetailContext();
   const [passageCount, setPassageCount] = useState(0);
@@ -88,7 +98,7 @@ export const PassageDetailChooser = () => {
   }, [view]);
 
   return passageCount > 1 ? (
-    <StyledBox>
+    <StyledBox width={width}>
       <Typography sx={{ pr: 2 }}>{t.passages}</Typography>
       <Tabs
         value={value || 0}

--- a/src/components/PassageDetail/PassageDetailChooser.tsx
+++ b/src/components/PassageDetail/PassageDetailChooser.tsx
@@ -37,7 +37,8 @@ interface IProps {
 
 export const PassageDetailChooser = ({ width }: IProps) => {
   const [memory] = useGlobal('memory');
-  const { passage, section, prjId, allBookData } = usePassageDetailContext();
+  const { passage, section, prjId, allBookData, chooserSize, setChooserSize } =
+    usePassageDetailContext();
   const [passageCount, setPassageCount] = useState(0);
   const [value, setValue] = useState(0);
   const marks = useRef<Array<Mark>>([]);
@@ -73,6 +74,8 @@ export const PassageDetailChooser = ({ width }: IProps) => {
     if (Array.isArray(passages)) {
       const newCount = passages.length;
       if (passageCount !== newCount) setPassageCount(newCount);
+      const newSize = newCount > 1 ? 48 : 0;
+      if (chooserSize !== newSize) setChooserSize(newSize);
       marks.current = [];
       passages.forEach((p) => {
         const passRec = findRecord(memory, 'passage', p.id) as Passage;

--- a/src/components/PassageDetail/PassageDetailItem.tsx
+++ b/src/components/PassageDetail/PassageDetailItem.tsx
@@ -232,7 +232,6 @@ export function PassageDetailItem(props: IProps & IRecordProps) {
   }, [organization]);
 
   const handleSplitSize = debounce((e: number) => {
-    console.log(`passageDetailItem split ${discussionSize.height}`);
     setDiscussionSize({ width: width - e, height: discussionSize.height });
   }, 50);
 

--- a/src/components/PassageDetail/PassageDetailPlayer.tsx
+++ b/src/components/PassageDetail/PassageDetailPlayer.tsx
@@ -76,6 +76,7 @@ export function PassageDetailPlayer(props: IProps) {
     setPlaying,
     currentstep,
     playerSize,
+    chooserSize,
     currentSegmentIndex,
     setCurrentSegment,
     discussionMarkers,
@@ -262,12 +263,13 @@ export function PassageDetailPlayer(props: IProps) {
     setInitialPosition(position);
   }, [position]);
 
+  console.log(`detailPlayer chooserSize: ${chooserSize}`);
   return (
     <div id="detailplayer">
       <WSAudioPlayer
         id="audioPlayer"
         allowRecord={false}
-        size={playerSize}
+        size={playerSize - chooserSize}
         blob={audioBlob}
         initialposition={initialposition}
         isPlaying={requestPlay.play}

--- a/src/components/PassageDetail/PassageDetailPlayer.tsx
+++ b/src/components/PassageDetail/PassageDetailPlayer.tsx
@@ -30,6 +30,7 @@ interface IProps {
   onInteraction?: () => void;
   allowZoomAndSpeed?: boolean;
   position?: number;
+  chooserReduce?: number;
 }
 
 export function PassageDetailPlayer(props: IProps) {
@@ -47,6 +48,7 @@ export function PassageDetailPlayer(props: IProps) {
     onInteraction,
     allowZoomAndSpeed,
     position,
+    chooserReduce,
   } = props;
 
   const [memory] = useGlobal('memory');
@@ -76,7 +78,6 @@ export function PassageDetailPlayer(props: IProps) {
     setPlaying,
     currentstep,
     playerSize,
-    chooserSize,
     currentSegmentIndex,
     setCurrentSegment,
     discussionMarkers,
@@ -263,13 +264,12 @@ export function PassageDetailPlayer(props: IProps) {
     setInitialPosition(position);
   }, [position]);
 
-  console.log(`detailPlayer chooserSize: ${chooserSize}`);
   return (
     <div id="detailplayer">
       <WSAudioPlayer
         id="audioPlayer"
         allowRecord={false}
-        size={playerSize - chooserSize}
+        size={playerSize - (chooserReduce ?? 0)}
         blob={audioBlob}
         initialposition={initialposition}
         isPlaying={requestPlay.play}

--- a/src/components/PassageDetail/RecordButtons.tsx
+++ b/src/components/PassageDetail/RecordButtons.tsx
@@ -1,0 +1,60 @@
+import { Button, ButtonGroup } from '@mui/material';
+import AddIcon from '@mui/icons-material/LibraryAddOutlined';
+import VersionsIcon from '@mui/icons-material/List';
+import { useGlobal } from 'reactn';
+import { shallowEqual, useSelector } from 'react-redux';
+import { passageRecordSelector, sharedSelector } from '../../selector';
+import { IPassageRecordStrings, ISharedStrings } from '../../model';
+import { IMediaState, MediaSt } from '../../crud';
+
+interface IProps {
+  mediaId: string;
+  mediaState?: IMediaState;
+  onVersions: () => void;
+  onUpload: () => void;
+  onReload: () => void;
+}
+
+export const RecordButtons = ({
+  mediaId,
+  mediaState,
+  onVersions,
+  onUpload,
+  onReload,
+}: IProps) => {
+  const [offlineOnly] = useGlobal('offlineOnly');
+  const ts: ISharedStrings = useSelector(sharedSelector, shallowEqual);
+  const t: IPassageRecordStrings = useSelector(
+    passageRecordSelector,
+    shallowEqual
+  );
+
+  return (
+    <ButtonGroup size="small" sx={{ my: 1 }}>
+      <Button
+        id="pdRecordVersions"
+        onClick={onVersions}
+        title={ts.versionHistory}
+      >
+        <VersionsIcon />
+        {ts.versionHistory}
+      </Button>
+      <Button
+        id="pdRecordUpload"
+        onClick={onUpload}
+        title={!offlineOnly ? ts.uploadMediaSingular : ts.importMediaSingular}
+      >
+        <AddIcon />
+        {!offlineOnly ? ts.uploadMediaSingular : ts.importMediaSingular}
+      </Button>
+      {mediaId &&
+        mediaState &&
+        mediaState.status === MediaSt.FETCHED &&
+        mediaState.id === mediaId && (
+          <Button id="pdRecordReload" onClick={onReload}>
+            {t.loadfile}
+          </Button>
+        )}
+    </ButtonGroup>
+  );
+};

--- a/src/components/Transcriber.tsx
+++ b/src/components/Transcriber.tsx
@@ -104,7 +104,7 @@ import { PlayInPlayer } from '../context/PassageDetailContext';
 //import useRenderingTrace from '../utils/useRenderingTrace';
 
 const HISTORY_KEY = 'F7,CTRL+7';
-const INIT_PLAYER_HEIGHT = 180 + 48; // 48 for possible passage chooser
+const INIT_PLAYER_HEIGHT = 180;
 
 const Wrapper = styledComp.div`
   .Resizer {
@@ -305,6 +305,7 @@ export function Transcriber(
     playing,
     playerSize,
     setPlayerSize,
+    chooserSize,
     pdBusy,
     playerMediafile,
     setSelected,
@@ -485,7 +486,7 @@ export function Transcriber(
   }, [toolsChanged]);
 
   useEffect(() => {
-    const newBoxHeight = discussionSize.height - playerSize;
+    const newBoxHeight = discussionSize.height - playerSize - chooserSize;
     if (newBoxHeight !== boxHeight) setBoxHeight(newBoxHeight);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [discussionSize, playerSize]);
@@ -992,7 +993,7 @@ export function Transcriber(
               <SplitPane
                 defaultSize={playerSize}
                 minSize={INIT_PLAYER_HEIGHT}
-                maxSize={discussionSize.height - 280}
+                maxSize={discussionSize.height - 280 - chooserSize}
                 style={{ position: 'static' }}
                 split="horizontal"
                 onChange={handleSplitSize}

--- a/src/components/Transcriber.tsx
+++ b/src/components/Transcriber.tsx
@@ -104,7 +104,7 @@ import { PlayInPlayer } from '../context/PassageDetailContext';
 //import useRenderingTrace from '../utils/useRenderingTrace';
 
 const HISTORY_KEY = 'F7,CTRL+7';
-const INIT_PLAYER_HEIGHT = 180;
+const INIT_PLAYER_HEIGHT = 180 + 48; // 48 for possible passage chooser
 
 const Wrapper = styledComp.div`
   .Resizer {

--- a/src/context/PassageDetailContext.tsx
+++ b/src/context/PassageDetailContext.tsx
@@ -184,6 +184,8 @@ const initState = {
   playerSize: 280,
   setDiscussionSize: (size: { width: number; height: number }) => {},
   setPlayerSize: (size: number) => {},
+  chooserSize: 48,
+  setChooserSize: (size: number) => {},
   defaultFilename: '',
   uploadItem: '',
   recordCb: (planId: string, MediaRemId?: string[]) => {},
@@ -353,6 +355,12 @@ const PassageDetailProvider = withData(mapRecordsToProps)(
     const setPlayerSize = (playerSize: number) => {
       setState((state: ICtxState) => {
         return { ...state, playerSize };
+      });
+    };
+
+    const setChooserSize = (chooserSize: number) => {
+      setState((state: ICtxState) => {
+        return { ...state, chooserSize };
       });
     };
 
@@ -1010,6 +1018,7 @@ const PassageDetailProvider = withData(mapRecordsToProps)(
             setFirstStepIndex,
             setDiscussionSize,
             setPlayerSize,
+            setChooserSize,
             setPlaying,
             setItemPlaying,
             setPlayItem,

--- a/src/routes/PassageDetail.tsx
+++ b/src/routes/PassageDetail.tsx
@@ -246,9 +246,6 @@ const PassageDetailGrids = () => {
         <Grid item sx={descProps} xs={12}>
           <WorkflowSteps />
         </Grid>
-        <Grid item xs={12}>
-          <PassageDetailChooser />
-        </Grid>
         {tool === ToolSlug.Resource && (
           <Grid container direction="row" sx={rowProps}>
             <Grid item xs={12}>
@@ -290,6 +287,9 @@ const PassageDetailGrids = () => {
                       onChange={handleHorzSplitSize}
                     >
                       <Pane>
+                        <PassageDetailChooser
+                          width={width - discussionSize.width - 16}
+                        />
                         {(tool !== ToolSlug.KeyTerm || mediafileId) && (
                           <PassageDetailPlayer />
                         )}
@@ -306,6 +306,9 @@ const PassageDetailGrids = () => {
                   )}
                   {tool === ToolSlug.Transcribe && (
                     <Grid item sx={descProps} xs={12}>
+                      <PassageDetailChooser
+                        width={width - discussionSize.width - 16}
+                      />
                       <PassageDetailTranscribe
                         width={width - discussionSize.width - 16}
                         artifactTypeId={artifactId}
@@ -315,6 +318,9 @@ const PassageDetailGrids = () => {
                   )}
                   {tool === ToolSlug.Record && (
                     <Grid item sx={descProps} xs={12}>
+                      <PassageDetailChooser
+                        width={width - discussionSize.width - 16}
+                      />
                       <PassageDetailRecord />
                     </Grid>
                   )}

--- a/src/routes/PassageDetail.tsx
+++ b/src/routes/PassageDetail.tsx
@@ -58,7 +58,7 @@ const KeyTerms = React.lazy(
   () => import('../components/PassageDetail/Keyterms/KeyTerms')
 );
 
-const minWidth = 800;
+const minWidth = 880;
 
 const descProps = { overflow: 'hidden', textOverflow: 'ellipsis' } as SxProps;
 const rowProps = { alignItems: 'center', whiteSpace: 'nowrap' } as SxProps;
@@ -128,7 +128,7 @@ const Pane = (props: PaneProps & PropsWithChildren) => {
 };
 
 const PassageDetailGrids = () => {
-  const INIT_PLAYERPANE_HEIGHT = 150;
+  const INIT_PLAYERPANE_HEIGHT = 150 + 48; // 48 for possible passage chooser
   const [plan] = useGlobal('plan');
   const [width, setWidth] = useState(window.innerWidth);
   const [height, setHeight] = useState(window.innerHeight);
@@ -280,7 +280,7 @@ const PassageDetailGrids = () => {
                   {tool !== ToolSlug.Transcribe && tool !== ToolSlug.Record && (
                     <SplitPane
                       defaultSize={playerSize}
-                      minSize={INIT_PLAYERPANE_HEIGHT}
+                      minSize={INIT_PLAYERPANE_HEIGHT + 48} // 48 for chooser
                       maxSize={height - 280}
                       style={{ position: 'static' }}
                       split="horizontal"


### PR DESCRIPTION
- prevents controls wrapping on recorders or players
- some tools require scrolling if screen is too narrow.
- save button always visible on record step
- record controls moved toward ui/ux recommended