### PR TITLE
TT-6139 Transcriber keeps current content

### DIFF
--- a/src/components/PassageDetail/Internalization/useProjectSegmentSave.ts
+++ b/src/components/PassageDetail/Internalization/useProjectSegmentSave.ts
@@ -18,6 +18,7 @@ export const useProjectSegmentSave = () => {
           type: 'mediafile',
           id: media.id,
           attributes: {
+            ...media?.attributes,
             segments: segments,
           },
         } as any as MediaFileD,

--- a/src/components/PassageDetail/PassageDetailPlayer.tsx
+++ b/src/components/PassageDetail/PassageDetailPlayer.tsx
@@ -141,6 +141,7 @@ export function PassageDetailPlayer(props: DetailPlayerProps) {
                 type: 'mediafile',
                 id: mediafile.id,
                 attributes: {
+                  ...mediafile?.attributes,
                   segments: updateSegments(
                     allowSegment ?? NamedRegions.BackTranslation,
                     mediafile.attributes?.segments || '{}',

--- a/src/components/Transcriber.tsx
+++ b/src/components/Transcriber.tsx
@@ -960,6 +960,7 @@ export function Transcriber(props: IProps) {
             type: 'mediafile',
             id: mediaRef.current.id,
             attributes: {
+              ...mediaRef.current?.attributes,
               transcription: transcription,
               position: newPosition,
               segments: updateSegments(


### PR DESCRIPTION
- current publishTo information should be retained.
- also fixes other times when segments were updated but media content removed.